### PR TITLE
fix: Resolve title toggle issue

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -157,11 +157,13 @@ function showSavedRecipes() {
 }
 
 function goHome() {
-  toggleHidden(myRecipesTitle);
-  toggleHidden(titleLogo);
-  savedView = false;
-  currentView = recipeRepo.recipes;
-  searchBar.placeholder = 'Search Recipes...';
-  filterHeader.innerText = 'Filter Recipes';
-  createRecipeCards(currentView);
+  if(currentView !== recipeRepo.recipes){
+    toggleHidden(myRecipesTitle);
+    toggleHidden(titleLogo);
+    savedView = false;
+    currentView = recipeRepo.recipes;
+    searchBar.placeholder = 'Search Recipes...';
+    filterHeader.innerText = 'Filter Recipes';
+    createRecipeCards(currentView);
+  }
 }


### PR DESCRIPTION
Files changed: scripts.js
Change Summary: Resolved issue where Home logo and user recipes title display were toggling even when home button is clicked, even when the user was already at home view.

This was resolved by adding a conditional  to the goHome function that only allows the goHome function to run if the currentView value was anything other than the all recipes (home view).