### PR TITLE
Feature/print view

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -86,7 +86,10 @@ function createRecipeModal(event) {
         ${createList(modalRecipe.getInstructions())}
         </ol>
         <h4 class="oregano-font"><i>TOTAL COST $${+(modalRecipe.listCost(ingredients))}</i></h4>
-        <button class="save-button pointer" id="saveBtn">${updateButtonText()}</button>
+        <div class="button-container">
+          <button class="modal-button pointer" id="saveBtn">${updateButtonText()}</button>
+          <button class="modal-button pointer" id="printBtn">Print Me!</button>
+        </div>
     </div>`;
     document.getElementById('saveBtn').addEventListener('click', toggleSaveRecipe);
   }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -74,24 +74,27 @@ function createRecipeModal(event) {
     <div class="recipe-popup">
         <img class="close-icon pointer" id="closeIcon" src="./images/close-icon.png" alt="close icon">
         <h2>${modalRecipe.name}</h2>
-        <div class="image-ingredients">
-        <img class="modal-img" src="${modalRecipe.image}" alt="${modalRecipe.name} image">
-        <ul class="oregano-font">
-            <h3>Ingredients:</h3>
-            ${createList(modalRecipe.listIngredients(ingredients))}
-        </ul>
+        <div class="print-container">
+          <div class="image-ingredients">
+          <img class="modal-img" src="${modalRecipe.image}" alt="${modalRecipe.name} image">
+          <ul class="oregano-font">
+              <h3>Ingredients:</h3>
+              ${createList(modalRecipe.listIngredients(ingredients))}
+          </ul>
+          </div>
+          <ol class="oregano-font">
+            <h3>Directions:</h3>
+            ${createList(modalRecipe.getInstructions())}
+          </ol>
         </div>
-        <ol class="oregano-font">
-        <h3>Directions:</h3>
-        ${createList(modalRecipe.getInstructions())}
-        </ol>
-        <h4 class="oregano-font"><i>TOTAL COST $${+(modalRecipe.listCost(ingredients))}</i></h4>
+        <h4 class="oregano-font"><i>TOTAL COST $${modalRecipe.listCost(ingredients)}</i></h4>
         <div class="button-container">
           <button class="modal-button pointer" id="saveBtn">${updateButtonText()}</button>
           <button class="modal-button pointer" id="printBtn">Print Me!</button>
         </div>
     </div>`;
     document.getElementById('saveBtn').addEventListener('click', toggleSaveRecipe);
+    document.getElementById('printBtn').addEventListener('click', () => window.print());
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -265,3 +265,42 @@ li {
     height: 1px;
     overflow: hidden;
 }
+
+@media print {
+  .nav-bar, .all-recipes, .modal-img, .modal-button, .close-icon, h4 {
+    display: none;
+  }
+
+  .recipe-popup {
+    font-size: 1.2rem;
+    height: auto;
+    width: 100%;
+    border: none;
+    background-color: white;
+    margin: 0;
+    overflow: visible;
+    padding: 0;
+  }
+
+  .recipe-popup > h2 {
+    margin: 0;
+  }
+
+  .print-container {
+    font-size: 1.5rem;
+    display: flex;
+  }
+
+  .print-container > ul {
+    width: 35%;
+  }
+
+  .print-container > ol {
+    width: 65%;
+    margin-top: 0;
+  }
+}
+
+@page {
+  margin: 2cm;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -211,14 +211,20 @@ body {
   filter: drop-shadow(3px 3px 3px black);
 }
 
-.save-button {
+.button-container {
+  margin-top: 5vmin;
+  display: flex;
+  justify-content: space-around;
+}
+
+.modal-button {
   font-family: inherit;
   background-color: white;
   color: black;
   border-radius: 5px;
 }
 
-.save-button:hover {
+.modal-button:hover {
   background-color: black;
   color: white;
 }


### PR DESCRIPTION
Files Changed: scripts.js, styles.css
Change Summary: 
This merge adds a print button to each recipe modal that is created that calls the window.print() method. The save-button class is now called modal-button and applies to both buttons. Two new divs were added to the recipe modal as well to help flex elements.
A print media query and page query were also created. The page query sets a page (the page being printed) margin of 2cm. The print media query applies when the window.print() method is called and hides all elements that are not part of the created and currently viewed modal. The image, icons, buttons and cost are also hidden so that only title, directions and ingredients are visible. Borders are also removed and background color is returned to white. Directions and ingredients are flexed to be side by side with a set width. Overflow is set back to visible to force all content onto the page. Recipe elements also have adjusted margins, paddings and font-sizes for better space-efficiency.

All recipes were tested with the print button and all fit (individually) onto one page that is very readable.

An example of the longest printed recipe is attached below:

[Printed Recipe.pdf](https://github.com/jfogiato/whats-cookin/files/10809720/Printed.Recipe.pdf)


Closes #91, Closes #90, Closes #89